### PR TITLE
Add macros for checking stash contents

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,7 +6,7 @@ AlignEscapedNewlines: Right
 AlignOperands: true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: false
+AllowShortBlocksOnASingleLine: Empty
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: false

--- a/.clang-format
+++ b/.clang-format
@@ -34,6 +34,7 @@ ForEachMacros:
   - cloge_info
   - cloge_notice
   - cloge_warning
+  - clog_message_fields_foreach
   - cork_dllist_foreach
 IncludeCategories:
   - Regex:    '^<.*\.h>'

--- a/include/clogger/api.h
+++ b/include/clogger/api.h
@@ -274,4 +274,14 @@ _clog_process_message(struct clog_message* message, const char* fmt, ...)
         CORK_ATTR_PRINTF(2, 3);
 
 
+/* clang-format off */
+#define cloge_message_fields                                                   \
+    for (bool __continue = true; __continue;)                                  \
+    for (struct clog_message_fields __field_list; __continue;)                 \
+    for (clog_message_fields_init(&__field_list); __continue;)                 \
+    for (struct clog_message_fields* __fields = &__field_list; __continue;)    \
+    for (; __continue; __continue = false)
+/* clang-format on */
+
+
 #endif /* CLOGGER_API_H */

--- a/include/clogger/fields.h
+++ b/include/clogger/fields.h
@@ -26,14 +26,14 @@ struct clog_string_field {
 
 CORK_INLINE
 void
-clog_message_add_string_field(struct clog_message* message,
+clog_message_add_string_field(struct clog_message_fields* fields,
                               struct clog_string_field* field, const char* key,
                               const char* value)
 {
     field->parent.key = key;
     field->parent.value = value;
     field->parent.done = NULL;
-    cork_dllist_add_to_tail(&message->fields, &field->parent.item);
+    clog_message_fields_push(fields, &field->parent);
 }
 
 
@@ -52,7 +52,7 @@ clog_printf_field_done(struct clog_message_field* field);
 CORK_INLINE
 CORK_ATTR_PRINTF(4, 5)
 void
-clog_message_add_printf_field(struct clog_message* message,
+clog_message_add_printf_field(struct clog_message_fields* fields,
                               struct clog_printf_field* field, const char* key,
                               const char* fmt, ...)
 {
@@ -64,7 +64,7 @@ clog_message_add_printf_field(struct clog_message* message,
     cork_buffer_vprintf(&field->value, fmt, args);
     va_end(args);
     field->parent.value = field->value.buf;
-    cork_dllist_add_to_tail(&message->fields, &field->parent.item);
+    clog_message_fields_push(fields, &field->parent);
 }
 
 

--- a/include/clogger/stash.h
+++ b/include/clogger/stash.h
@@ -29,4 +29,11 @@ clog_stash_contains_event(const struct clog_stash* stash, ...);
 struct clog_handler*
 clog_stashing_handler_new(struct clog_stash* stash);
 
+#define clog_stash_contains_message(stash)                                     \
+    clog_stash_contains_message_fields((stash), __fields)
+
+bool
+clog_stash_contains_message_fields(const struct clog_stash* stash,
+                                   struct clog_message_fields* fields);
+
 #endif /* CLOGGER_STASH_H */

--- a/src/libclogger/fields.c
+++ b/src/libclogger/fields.c
@@ -14,7 +14,7 @@
 #include "clogger/fields.h"
 
 void
-clog_message_add_string_field(struct clog_message* message,
+clog_message_add_string_field(struct clog_message_fields* fields,
                               struct clog_string_field* field, const char* key,
                               const char* value);
 
@@ -27,6 +27,6 @@ clog_printf_field_done(struct clog_message_field* vfield)
 }
 
 void
-clog_message_add_printf_field(struct clog_message* message,
+clog_message_add_printf_field(struct clog_message_fields* fields,
                               struct clog_printf_field* field, const char* key,
                               const char* fmt, ...);

--- a/src/libclogger/formatter.c
+++ b/src/libclogger/formatter.c
@@ -325,11 +325,8 @@ var_segment_message(struct segment* vself, struct clog_message* message)
 {
     struct var_segment* self =
             cork_container_of(vself, struct var_segment, parent);
-    struct cork_dllist_item *curr;
-    struct cork_dllist_item *next;
     struct clog_message_field* field;
-    cork_dllist_foreach (&message->fields, curr, next,
-                         struct clog_message_field, field, item) {
+    clog_message_fields_foreach (&message->fields, field) {
         if (strcmp(field->key, self->name) == 0) {
             size_t i;
             self->value_given = true;
@@ -422,12 +419,9 @@ multi_segment_message(struct segment* vself, struct clog_message* message)
 {
     struct multi_segment* self =
             cork_container_of(vself, struct multi_segment, parent);
-    struct cork_dllist_item *curr;
-    struct cork_dllist_item *next;
     struct clog_message_field* field;
     self->value_given = true;
-    cork_dllist_foreach (&message->fields, curr, next,
-                         struct clog_message_field, field, item) {
+    clog_message_fields_foreach (&message->fields, field) {
         size_t i;
         for (i = 0; i < cork_array_size(&self->segments); i++) {
             struct annotation_segment* segment =

--- a/src/libclogger/formatter.c
+++ b/src/libclogger/formatter.c
@@ -326,7 +326,7 @@ var_segment_message(struct segment* vself, struct clog_message* message)
     struct var_segment* self =
             cork_container_of(vself, struct var_segment, parent);
     struct clog_message_field* field;
-    clog_message_fields_foreach (&message->fields, field) {
+    for (field = message->fields.head; field != NULL; field = field->next) {
         if (strcmp(field->key, self->name) == 0) {
             size_t i;
             self->value_given = true;
@@ -419,9 +419,12 @@ multi_segment_message(struct segment* vself, struct clog_message* message)
 {
     struct multi_segment* self =
             cork_container_of(vself, struct multi_segment, parent);
-    struct clog_message_field* field;
     self->value_given = true;
-    clog_message_fields_foreach (&message->fields, field) {
+    struct clog_message_field* head = message->fields.head;
+    struct clog_message_field* last;
+    struct clog_message_field* field;
+    for (last = NULL; last != head; last = field) {
+        for (field = head; field->next != last; field = field->next) {}
         size_t i;
         for (i = 0; i < cork_array_size(&self->segments); i++) {
             struct annotation_segment* segment =

--- a/src/libclogger/stack.c
+++ b/src/libclogger/stack.c
@@ -131,6 +131,20 @@ void
 clog_message_field_done(struct clog_message_field* field);
 
 void
+clog_message_fields_init(struct clog_message_fields* fields);
+
+void
+clog_message_fields_push(struct clog_message_fields* fields,
+                         struct clog_message_field* field);
+
+void
+clog_message_fields_pop(struct clog_message_fields* fields,
+                        struct clog_message_field* field);
+
+void
+clog_message_fields_done(struct clog_message_fields* fields);
+
+void
 clog_message_init(struct clog_message* message, enum clog_level level,
                   const char* channel);
 

--- a/src/libclogger/stash.c
+++ b/src/libclogger/stash.c
@@ -69,6 +69,23 @@ clog_stashed_event_matches(const struct clog_stashed_event* event, va_list args)
     }
 }
 
+static bool
+clog_stashed_event_matches_message_fields(
+        const struct clog_stashed_event* event,
+        struct clog_message_fields* fields)
+{
+    struct clog_message_field* field;
+    for (field = fields->head; field != NULL; field = field->next) {
+        const char* key = field->key;
+        const char* expected = field->value;
+        const char *actual = cork_hash_table_get(event->fields, key);
+        if (actual == NULL || strcmp(expected, actual) != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
 static void
 clog_stashed_event_add(struct clog_stashed_event* event, const char* key,
                        const char* value)
@@ -123,6 +140,20 @@ clog_stash_contains_event(const struct clog_stash* stash, ...)
         bool matches = clog_stashed_event_matches(
                 cork_array_at(&stash->events, i), args);
         va_end(args);
+        if (matches) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool
+clog_stash_contains_message_fields(const struct clog_stash* stash,
+                                   struct clog_message_fields* fields)
+{
+    for (size_t i = 0; i < cork_array_size(&stash->events); i++) {
+        bool matches = clog_stashed_event_matches_message_fields(
+                cork_array_at(&stash->events, i), fields);
         if (matches) {
             return true;
         }

--- a/src/libclogger/stash.c
+++ b/src/libclogger/stash.c
@@ -142,11 +142,8 @@ clog_stashing_handler_handle(struct clog_handler* handler,
     struct clog_stashing_handler* self =
             cork_container_of(handler, struct clog_stashing_handler, parent);
     struct clog_stashed_event* event = clog_stashed_event_new();
-    struct cork_dllist_item *curr;
-    struct cork_dllist_item *next;
     struct clog_message_field* field;
-    cork_dllist_foreach (&message->fields, curr, next,
-                         struct clog_message_field, field, item) {
+    clog_message_fields_foreach (&message->fields, field) {
         clog_stashed_event_add(event, field->key, field->value);
     }
     clog_stashed_event_add(event, "__message", clog_message_message(message));

--- a/src/libclogger/stash.c
+++ b/src/libclogger/stash.c
@@ -143,7 +143,7 @@ clog_stashing_handler_handle(struct clog_handler* handler,
             cork_container_of(handler, struct clog_stashing_handler, parent);
     struct clog_stashed_event* event = clog_stashed_event_new();
     struct clog_message_field* field;
-    clog_message_fields_foreach (&message->fields, field) {
+    for (field = message->fields.head; field != NULL; field = field->next) {
         clog_stashed_event_add(event, field->key, field->value);
     }
     clog_stashed_event_add(event, "__message", clog_message_message(message));

--- a/tests/test-formatter.c
+++ b/tests/test-formatter.c
@@ -82,8 +82,8 @@ test_message(struct clog_formatter *self, struct cork_buffer *dest,
     struct clog_string_field var1;
     struct clog_string_field var2;
     clog_message_init(&message, level, channel);
-    clog_message_add_string_field(&message, &var1, "var1", "value1");
-    clog_message_add_string_field(&message, &var2, "var2", "value2");
+    clog_message_add_string_field(&message.fields, &var1, "var1", "value1");
+    clog_message_add_string_field(&message.fields, &var2, "var2", "value2");
     message.fmt = fmt;
     va_start(message.args, fmt);
     clog_formatter_format_message(self, dest, &message);

--- a/tests/test-logging.c
+++ b/tests/test-logging.c
@@ -150,8 +150,10 @@ annotate_handle(struct clog_handler *log, struct clog_message* message)
     if (log->next != NULL) {
         struct clog_string_field key1;
         struct clog_string_field key2;
-        clog_message_add_string_field(message, &key1, "key1", "value1");
-        clog_message_add_string_field(message, &key2, "key2", "value2");
+        clog_message_add_string_field(&message->fields, &key1, "key1",
+                                      "value1");
+        clog_message_add_string_field(&message->fields, &key2, "key2",
+                                      "value2");
         clog_handler_handle(log->next, message);
         clog_message_pop_field(message, &key2.parent);
         clog_message_pop_field(message, &key1.parent);

--- a/tests/test-stash.c
+++ b/tests/test-stash.c
@@ -64,6 +64,21 @@ START_TEST(test_stash)
     ck_assert(clog_stash_contains_event(stash, "field1", "hello", NULL));
     ck_assert(!clog_stash_contains_event(stash, "field1", "there", NULL));
 
+    cloge_message_fields {
+        clog_add_field(__message, string, "Critical event");
+        ck_assert(clog_stash_contains_message(stash));
+    }
+
+    cloge_message_fields {
+        clog_add_field(field1, string, "hello");
+        ck_assert(clog_stash_contains_message(stash));
+    }
+
+    cloge_message_fields {
+        clog_add_field(field1, string, "there");
+        ck_assert(!clog_stash_contains_message(stash));
+    }
+
     fail_if_error(clog_handler_pop_process(handler));
     clog_handler_free(handler);
     clog_stash_free(stash);


### PR DESCRIPTION
This lets you use the same syntax to construct the "expected" message when verifying the contents of a stash, that you use when logging the messages in the first place.  This can be especially helpful if you have any specialized field types and want to reuse them in your test cases.

This patch also tightens up the field representation a bit.